### PR TITLE
Fixing need to type double

### DIFF
--- a/dist/helpers/accessor.js
+++ b/dist/helpers/accessor.js
@@ -9,7 +9,15 @@
 module.exports = function access(form) {
   return new Proxy(form, {
     get: function get(target, key) {
-      return Object.keys(target.data).includes(key) ? target.data[key] : target[key];
+      if (Object.keys(target.data).includes(key)) {
+        if (!Object.keys(target).includes(key)) {
+          target[key] = null; // Initialize an empty key if the property does not exist.
+        }
+
+        return target.data[key];
+      }
+
+      return target[key];
     },
     set: function set(target, key, value) {
       target.data[key] = value;

--- a/src/helpers/accessor.js
+++ b/src/helpers/accessor.js
@@ -8,10 +8,18 @@
  */
 module.exports = function access(form) {
 	return new Proxy(form, {
-		get: (target, key) => Object.keys
-    		(target.data).includes(key)
-	    		? target.data[key]
-		    	: target[key],
+		get (target, key){
+			if(Object.keys(target.data).includes(key)) {
+
+				if(!Object.keys(target).includes(key)) {
+					target[key] = null; // Initialize an empty key if the property does not exist.
+				}
+
+				return target.data[key];
+			}
+			
+			return target[key]
+			},
 
 		set (target, key, value) {
 			target.data[key] = value;


### PR DESCRIPTION
When using a `v-model` you need to type the first character twice.

After some investigation I found that when the proxy was applied it removed the initial form property value form the state if it was empty.

This will initalize a new empty property if some does not already exist making it possible to not have to type twice.